### PR TITLE
call getUtxos with 'undefined' instead of 'null'

### DIFF
--- a/src/Cardano/Wallet.js
+++ b/src/Cardano/Wallet.js
@@ -24,7 +24,7 @@ export const _getUnusedAddresses = api => () => api.getUnusedAddresses();
 export const _getUsedAddresses = api => page => () => api.getUsedAddresses(page);
 export const _signTx = api => tx => partial => () => api.signTx(tx, partial);
 export const _signData = api => addr => payload => () => api.signData(addr, payload);
-export const _getUtxos = api => paginate => () => api.getUtxos(paginate);
+export const _getUtxos = api => paginate => () => api.getUtxos(paginate != null ? paginate : undefined);
 export const _submitTx = api => tx => () => api.submitTx(tx.to_hex());
 
 export const isWalletAvailable = walletName => () =>


### PR DESCRIPTION
The [api.getUtxos(..)](https://cips.cardano.org/cips/cip30/#apigetutxosamountcborvalueundefinedpaginatepaginateundefinedpromisetransactionunspentoutputnull) spec is somehow subtle at this point in case you want all UTxOs without any pagination. But it turned out, if the JS API is called with the parameter value `null` the promise stays unfulfilled forever. Whereas if it is called with the value `undefined` (or without any parameter) it work's as expected.