### PR TITLE
transaction parameter of submitTx is already hex encoded (CBOR)

### DIFF
--- a/src/Cardano/Wallet.js
+++ b/src/Cardano/Wallet.js
@@ -25,7 +25,7 @@ export const _getUsedAddresses = api => page => () => api.getUsedAddresses(page)
 export const _signTx = api => tx => partial => () => api.signTx(tx, partial);
 export const _signData = api => addr => payload => () => api.signData(addr, payload);
 export const _getUtxos = api => paginate => () => api.getUtxos(paginate != null ? paginate : undefined);
-export const _submitTx = api => tx => () => api.submitTx(tx.to_hex());
+export const _submitTx = api => tx => () => api.submitTx(tx);
 
 export const isWalletAvailable = walletName => () =>
    typeof window.cardano != "undefined" &&


### PR DESCRIPTION
Hi Anton, a mini bugfix: The `tx` parameter of `submitTx` is already hex encoded (like the `tx` parameter of `signTx`). After removing the `to_hex()` call in **Wallet.js** the transactions are submitted successfully. Tested on "Cardano Preview Testnet".